### PR TITLE
feature: add support for interacting with filters

### DIFF
--- a/bin/task-filter
+++ b/bin/task-filter
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../dist/src/task-filter');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             POSTGRES_PASSWORD: taskforge
 
     api:
-        image: taskforge/backend:0.6.0
+        image: taskforge/backend:0.7.0
         depends_on:
             - 'db'
         ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -862,9 +862,9 @@
       }
     },
     "@taskforge/sdk": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@taskforge/sdk/-/sdk-0.2.7.tgz",
-      "integrity": "sha512-mtwQoF6WsTrTjHbpmZvk+fZVxl3hpaRoSXMbyF6SX/x/qQVduQ3AGAo34xFSKd27alm7WmnfYxGVYut161KKmw==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@taskforge/sdk/-/sdk-0.3.6.tgz",
+      "integrity": "sha512-TwdpxRQqosJDx2kcmlanWcNOTChqSIFm27TpSOkUPIRZfapfNFW6DYGATsIdYEhr7kPnWNGwxGMRDuAtES+Pfw==",
       "requires": {
         "@types/node-fetch": "^2.5.7",
         "node-fetch": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "task-complete": "bin/task-complete",
     "task-register": "bin/task-register",
     "task-login": "bin/task-login",
-    "task-defer": "bin/task-defer"
+    "task-defer": "bin/task-defer",
+    "task-filter": "bin/task-filter"
   },
   "scripts": {
     "build": "tsc",
@@ -63,7 +64,7 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "@taskforge/sdk": "^0.2.7",
+    "@taskforge/sdk": "^0.3.6",
     "commander": "^5.1.0",
     "kleur": "^4.0.2",
     "ora": "^4.0.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,5 +31,6 @@ cli.command('add', 'add a task to your list')
     .command('register', 'register a new account with the taskforge server')
     .command('login', 'generate a personal access token')
     .command('defer', "defer the current task by reducing it's priority")
+    .command('filter', 'save queries for repeated use')
     .version(version)
     .parse(process.argv);

--- a/src/task-filter.ts
+++ b/src/task-filter.ts
@@ -1,0 +1,146 @@
+import { Command } from 'commander';
+
+import { filters, tasks, isAPIError } from '@taskforge/sdk';
+
+import { fail, unexpected } from './utils';
+import { printList } from './printing';
+
+async function save(name: string, query: string[]): Promise<void> {
+    const joined = query.join(' ');
+    if (!joined || joined == '') {
+        console.log('Must provide a query!');
+        process.exit(1);
+    }
+
+    const saved = await filters.create({
+        name,
+        query: joined
+    });
+    if (isAPIError(saved)) {
+        fail(saved);
+    }
+}
+
+async function update(name: string, query: string[]): Promise<void> {
+    const joined = query.join(' ');
+    if (!joined || joined == '') {
+        console.log('Must provide a query!');
+        process.exit(1);
+    }
+
+    const filter = await filters.byName(name);
+    if (isAPIError(filter)) {
+        fail(filter);
+        return;
+    }
+
+    const updated = await filters.update({
+        ...filter,
+        query: joined
+    });
+    if (isAPIError(updated)) {
+        fail(updated);
+    }
+}
+
+async function del(name: string): Promise<void> {
+    const filter = await filters.byName(name);
+    if (isAPIError(filter)) {
+        fail(filter);
+        return;
+    }
+
+    const deleted = await filters.del(filter.id);
+    if (isAPIError(deleted)) {
+        fail(deleted);
+    }
+}
+
+async function run(name: string, opts: Command): Promise<void> {
+    const filter = await filters.byName(name);
+    if (isAPIError(filter)) {
+        fail(filter);
+        return;
+    }
+
+    const list = await tasks.search(filter.query);
+    if (isAPIError(list)) {
+        fail(list);
+        return;
+    }
+
+    printList(list, opts.output);
+}
+
+async function list(opts: Command): Promise<void> {
+    const list = await filters.list();
+    if (isAPIError(list)) {
+        fail(list);
+        return;
+    }
+
+    for (const f of list) {
+        if (opts.verbose) {
+            console.log(f.name, f.query);
+        } else {
+            console.log(f.name);
+        }
+    }
+}
+
+async function main() {
+    try {
+        const saveCommand = new Command('save');
+        saveCommand
+            .description('save query as name for later use')
+            .arguments('<name> [query...]')
+            .action(save);
+
+        const updateCommand = new Command('update');
+        updateCommand
+            .description('update the filter name with the new query')
+            .arguments('update <name> [query...]')
+            .action(update);
+
+        const deleteCommand = new Command('delete');
+        deleteCommand
+            .description('delete the given query')
+            .arguments('delete <name>')
+            .action(del);
+
+        const listCommand = new Command('list');
+        listCommand
+            .description('list your saved filters')
+            .option(
+                '-v --verbose',
+                'print the associated query as well as the name of the filter',
+                false
+            )
+            .arguments('list')
+            .action(list);
+
+        const runCommmand = new Command('run');
+        runCommmand
+            .description('run the filter with name, print resulting tasks')
+            .option(
+                '-o --output <format>',
+                'output format for the tasks, available formats: table, json, csv',
+                'table'
+            )
+            .arguments('<name>')
+            .action(run);
+
+        const cli = new Command();
+        cli.addCommand(saveCommand);
+        cli.addCommand(updateCommand);
+        cli.addCommand(deleteCommand);
+        cli.addCommand(runCommmand);
+        cli.addCommand(listCommand);
+
+        cli.parse(process.argv);
+    } catch (e) {
+        unexpected(e);
+    }
+}
+
+main();

--- a/tests/test-filter-cmd.ts
+++ b/tests/test-filter-cmd.ts
@@ -1,0 +1,57 @@
+import { cli, listFilters, generateTask, generateUser } from './utils';
+
+describe('task filter', () => {
+    test('filter save allows the creation of a filter', async () => {
+        const { ownerId, token } = await generateUser();
+        await cli('filter save test-filter completed = false', token);
+        const filterList = await listFilters(token);
+        expect(filterList.length).toBe(1);
+        expect(filterList[0].name).toBe('test-filter');
+        expect(filterList[0].owner).toBe(ownerId);
+        expect(filterList[0].query).toBe('completed = false');
+    });
+
+    test('filter run runs the query', async () => {
+        const { token } = await generateUser();
+        await cli('filter save test-run-filter completed = false', token);
+        const task1 = await generateTask(token);
+        await generateTask(token, null, true);
+        const expected = [task1];
+        await generateTask(token, {}, true);
+        const { stdout } = await cli(
+            'filter run -o json test-run-filter',
+            token
+        );
+        const parsed = JSON.parse(stdout);
+        expect(parsed).toStrictEqual(expected);
+    });
+
+    test('filter update updates the query', async () => {
+        const { token } = await generateUser();
+        await cli('filter save test-update-filter completed = false', token);
+        await cli('filter update test-update-filter completed = true', token);
+        const filterList = await listFilters(token);
+        expect(filterList[0].name).toBe('test-update-filter');
+        expect(filterList[0].query).toBe('completed = true');
+    });
+
+    test('filter delete deletes the filter', async () => {
+        const { token } = await generateUser();
+        await cli('filter save test-delete-filter completed = false', token);
+        const filterList = await listFilters(token);
+        expect(filterList.length).toBe(1);
+        await cli('filter delete test-delete-filter', token);
+        const filterListAfter = await listFilters(token);
+        expect(filterListAfter.length).toBe(0);
+    });
+
+    test('filter list lists available filter names', async () => {
+        const { token } = await generateUser();
+        await cli('filter save test-list-filter1 completed = true', token);
+        await cli('filter save test-list-filter2 completed = true', token);
+        const filterList = await listFilters(token);
+        expect(filterList.length).toBe(2);
+        const { stdout } = await cli('filter list', token);
+        expect(stdout).toMatch(filterList.map((f) => f.name).join('\n'));
+    });
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -7,6 +7,7 @@ import {
     APIError,
     isAPIError,
     users,
+    Filter,
     Task
 } from '@taskforge/sdk';
 
@@ -195,4 +196,13 @@ export function tableRegexp(email: string, tasks: any[]): RegExp {
         .join('');
 
     return new RegExp(top + header + divider + tasksRegex + bottom);
+}
+
+export async function listFilters(token: string): Promise<Filter[]> {
+    const res = await withOptions.filters.list(options(token));
+    if (isAPIError(res)) {
+        throw new Error(`Listing Filters: ${res.code}: ${res.message}`);
+    }
+
+    return res;
 }


### PR DESCRIPTION
Filters are saved queries that can later be referenced by a short name.
For example the filter named completed would contain the query
'completed = true'.

The filter subcommand supports creating, updated, listing, running, and
deleting filters. This brings it more in line with the web frontend.
