### PR TITLE
feature: support context switching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -862,9 +862,9 @@
       }
     },
     "@taskforge/sdk": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@taskforge/sdk/-/sdk-0.3.6.tgz",
-      "integrity": "sha512-TwdpxRQqosJDx2kcmlanWcNOTChqSIFm27TpSOkUPIRZfapfNFW6DYGATsIdYEhr7kPnWNGwxGMRDuAtES+Pfw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@taskforge/sdk/-/sdk-0.3.7.tgz",
+      "integrity": "sha512-fINmG6/l134YeOqfJMaYo9pgcoCayIsvFh6+43seEos42IV+miUxK/mCQxVK89rrzkUIqDW13iAojeTa4M/iVg==",
       "requires": {
         "@types/node-fetch": "^2.5.7",
         "node-fetch": "^2.6.0"
@@ -6451,6 +6451,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "15.4.0",

--- a/package.json
+++ b/package.json
@@ -64,11 +64,12 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "@taskforge/sdk": "^0.3.6",
+    "@taskforge/sdk": "^0.3.7",
     "commander": "^5.1.0",
     "kleur": "^4.0.2",
     "ora": "^4.0.5",
     "prompts": "^2.3.2",
-    "table": "^5.4.6"
+    "table": "^5.4.6",
+    "yaml": "^1.10.0"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,33 @@
+import path from 'path';
+import YAML from 'yaml';
+import { existsSync, readFileSync } from 'fs';
+
+import { configDir } from './utils';
+
+const CONFIG = {};
+
+const CONFIG_FILE_LOCATIONS = [
+    'Taskforge.yaml',
+    'Taskforge.yml',
+    path.join(configDir(), 'config.yaml')
+];
+
+function loadConfigFile(): void {
+    let fp: string | undefined;
+    for (const location in CONFIG_FILE_LOCATIONS) {
+        if (existsSync(location)) {
+            fp = location;
+            break;
+        }
+    }
+
+    if (!fp) {
+        return;
+    }
+
+    const data = readFileSync(fp);
+    Object.assign(CONFIG, YAML.parse(data.toString('utf-8')));
+}
+
+loadConfigFile();
+export default CONFIG;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { LoginCommand } from './task-login';
 import { NextCommand } from './task-next';
 import { RegisterCommand } from './task-register';
 import { ShowCommand } from './task-show';
+import { SwitchContextCommand } from './task-switch-context';
 import { TodoCommand } from './task-todo';
 import { WorkOnCommand } from './task-work-on';
 
@@ -26,6 +27,7 @@ cli.version(version)
     .addCommand(NextCommand)
     .addCommand(RegisterCommand)
     .addCommand(ShowCommand)
+    .addCommand(SwitchContextCommand)
     .addCommand(TodoCommand)
     .addCommand(WorkOnCommand)
     .parse(process.argv);

--- a/src/printing.ts
+++ b/src/printing.ts
@@ -117,20 +117,6 @@ export function printList(list: Task[], format: string): void {
     }
 }
 
-export async function highestPriority(): Promise<number> {
-    const current = await tasks.current();
-    if (isAPIError(current)) {
-        if (current.code === 404) {
-            return 2;
-        }
-
-        fail(current);
-        return 0;
-    }
-
-    return current.priority;
-}
-
 export async function printTask(task: Task): Promise<void> {
     const humanized = await humanize(task);
     const data: any[][] = Object.keys(humanized).map((key) => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,48 @@
+import path from 'path';
+import { promises as fs } from 'fs';
+
+import { dataDir } from './utils';
+
+export interface State {
+    currentContext?: string;
+}
+
+/**
+ * Returns the path to the application state file.
+ *
+ */
+function stateFile(): string {
+    return path.join(dataDir(), 'state.json');
+}
+
+/**
+ * Load the application state from the stateFile
+ *
+ */
+export async function loadState(): Promise<State> {
+    try {
+        const fn = stateFile();
+        await fs.stat(fn);
+        const data = await fs.readFile(fn);
+        return JSON.parse(data.toString('utf-8')) as State;
+    } catch {
+        return {};
+    }
+}
+
+/**
+ * Save the given state to the stateFile
+ *
+ * @param state - State object to be saved
+ *
+ */
+export async function saveState(state: State): Promise<void> {
+    try {
+        await fs.stat(dataDir());
+    } catch {
+        await fs.mkdir(dataDir(), { recursive: true });
+    }
+
+    const data = JSON.stringify(state);
+    await fs.writeFile(stateFile(), data);
+}

--- a/src/task-complete.ts
+++ b/src/task-complete.ts
@@ -1,14 +1,17 @@
 import { isAPIError, tasks } from '@taskforge/sdk';
 import { Command } from 'commander';
 
+import { getNext } from './task-next';
 import { fail, unexpected } from './utils';
 
 async function complete(ids: string[]) {
     try {
         if (ids.length === 0) {
-            const task = await tasks.current();
-            if (isAPIError(task)) {
-                fail(task);
+            const task = await getNext();
+            if (!task) {
+                console.log(
+                    'No ids given and no next task found. Nothing to do.'
+                );
                 return;
             }
 

--- a/src/task-next.ts
+++ b/src/task-next.ts
@@ -1,24 +1,30 @@
-import { isAPIError, tasks } from '@taskforge/sdk';
+import { isAPIError, Task, tasks } from '@taskforge/sdk';
 import { Command } from 'commander';
 
 import { printJSON } from './printing';
 import { fail, unexpected } from './utils';
 import { loadState } from './state';
 
+export async function getNext(): Promise<Task | null> {
+    const state = await loadState();
+    const requestOptions = state.currentContext
+        ? { context: state.currentContext }
+        : {};
+
+    const task = await tasks.current(requestOptions);
+    if (isAPIError(task)) {
+        if (task.code !== 404) fail(task);
+        return null;
+    }
+
+    return task;
+}
+
 async function next(opts: Command) {
     try {
-        const state = await loadState();
-        const requestOptions = state.currentContext
-            ? { context: state.currentContext }
-            : {};
-        const task = await tasks.current(requestOptions);
-        if (isAPIError(task)) {
-            if (task.code === 404) {
-                console.log('All done! No more unfinished tasks.');
-                return;
-            }
-
-            fail(task);
+        const task = await getNext();
+        if (!task) {
+            console.log('All done! No more unfinished tasks.');
             return;
         }
 

--- a/src/task-next.ts
+++ b/src/task-next.ts
@@ -3,10 +3,15 @@ import { Command } from 'commander';
 
 import { printJSON } from './printing';
 import { fail, unexpected } from './utils';
+import { loadState } from './state';
 
 async function next(opts: Command) {
     try {
-        const task = await tasks.current();
+        const state = await loadState();
+        const requestOptions = state.currentContext
+            ? { context: state.currentContext }
+            : {};
+        const task = await tasks.current(requestOptions);
         if (isAPIError(task)) {
             if (task.code === 404) {
                 console.log('All done! No more unfinished tasks.');

--- a/src/task-switch-context.ts
+++ b/src/task-switch-context.ts
@@ -1,0 +1,24 @@
+import { Command } from 'commander';
+
+import { loadState, saveState } from './state';
+
+async function switchContext(context: string, opts: Command) {
+    const state = await loadState();
+
+    if (opts.reset && state.currentContext) {
+        delete state['currentContext'];
+    } else if (!opts.reset) {
+        state.currentContext = context;
+    }
+
+    await saveState(state);
+}
+
+export const SwitchContextCommand = new Command('switch-context')
+    .alias('sc')
+    .option('-r, --reset', 'reset context back to none')
+    .arguments('[context]')
+    .description(
+        'switch the current context, changes task next to only consider the given context'
+    )
+    .action(switchContext);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import kleur from 'kleur';
 import { APIError, tasks, isAPIError } from '@taskforge/sdk';
 
@@ -30,4 +31,44 @@ export async function highestPriority(): Promise<number> {
         unexpected(e);
         return 0;
     }
+}
+
+/**
+ * Finds the platform-specific config dir
+ *
+ * @remarks
+ * Follows the XDG specification for all platforms then will use a resonable
+ * default based on platform.
+ *
+ */
+export function configDir(): string {
+    if (process.env.XDG_CONFIG_HOME) {
+        return path.join(process.env.XDG_CONFIG_HOME, 'taskforge');
+    }
+
+    if (process.platform === 'win32') {
+        return path.join(process.env.APPDATA!, 'Taskforge', 'config');
+    }
+
+    return path.join(process.env.HOME!, '.config', 'taskforge');
+}
+
+/**
+ * Returns the platform-specific user data dir
+ *
+ * @remarks
+ * Follows the XDG specification for all platforms then will use a resonable
+ * default based on platform.
+ *
+ */
+export function dataDir(): string {
+    if (process.env.XDG_DATA_HOME) {
+        return path.join(process.env.XDG_DATA_HOME, 'taskforge');
+    }
+
+    if (process.platform === 'win32') {
+        return path.join(process.env.APPDATA!, 'Taskforge', 'data');
+    }
+
+    return path.join(process.env.HOME!, '.local', 'share', 'taskforge');
 }

--- a/tests/test-switch-context.ts
+++ b/tests/test-switch-context.ts
@@ -1,0 +1,50 @@
+import {
+    cli,
+    genDir,
+    generateTask,
+    generateUser,
+    createContext
+} from './utils';
+
+describe('task switch-context', () => {
+    test('switches the context', async () => {
+        const { token } = await generateUser();
+        const so = { dataDir: genDir() };
+        const context = await createContext(token, 'non-default');
+
+        const expected = await generateTask(token, { context });
+        const top = await generateTask(token, { priority: 2 });
+
+        const verify = await cli('next', token, so);
+        const rgx = new RegExp(`^${top.id} ${top.title}`);
+        expect(verify.stdout).toMatch(rgx);
+
+        await cli('switch-context non-default', token, so);
+        const switched = await cli('next', token, so);
+        const switchedRgx = new RegExp(`^${expected.id} ${expected.title}`);
+        expect(switched.stdout).toMatch(switchedRgx);
+    });
+
+    test('resets the context', async () => {
+        const { token } = await generateUser();
+        const so = { dataDir: genDir() };
+        const context = await createContext(token, 'non-default');
+
+        const expected = await generateTask(token, { context });
+        const top = await generateTask(token, { priority: 2 });
+
+        const verify = await cli('next', token, so);
+        const rgx = new RegExp(`^${top.id} ${top.title}`);
+        expect(verify.stdout).toMatch(rgx);
+
+        await cli('switch-context non-default', token, so);
+        const switched = await cli('next', token, so);
+        const switchedRgx = new RegExp(`^${expected.id} ${expected.title}`);
+        expect(switched.stdout).toMatch(switchedRgx);
+
+        await cli('switch-context --reset', token, so);
+        const reset = await cli('next', token, so);
+        const resetRgx = new RegExp(`^${top.id} ${top.title}`);
+        expect(reset.stdout).toMatch(resetRgx);
+    });
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import os from 'os';
 import { exec, ExecException } from 'child_process';
 
 import {
@@ -11,7 +12,7 @@ import {
     Task
 } from '@taskforge/sdk';
 
-function makeid(): string {
+export function makeid(): string {
     const length = 50;
     const characters =
         'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
@@ -23,6 +24,10 @@ function makeid(): string {
         );
     }
     return result;
+}
+
+export function genDir(): string {
+    return path.join(os.tmpdir(), makeid());
 }
 
 export function fail<T>(obj: APIError | T): T {
@@ -138,11 +143,24 @@ export function taskBin(): string {
     return path.join(cwd(), 'bin', 'task');
 }
 
-export function spawnOpts(token: string) {
+export interface SpawnOpts {
+    dataDir?: string;
+    configDir?: string;
+}
+
+export function spawnOpts(token: string, opts?: SpawnOpts) {
     return {
         cwd: cwd(),
         maxBuffer: 200 * 1024,
         env: {
+            XDG_DATA_HOME:
+                opts && opts.dataDir
+                    ? opts.dataDir
+                    : path.join(os.tmpdir(), makeid()),
+            XDG_CONFIG_HOME:
+                opts && opts.configDir
+                    ? opts.configDir
+                    : path.join(os.tmpdir(), makeid()),
             PATH: process.env.PATH,
             TASKFORGE_HOST: process.env.TASKFORGE_HOST,
             TASKFORGE_TOKEN: token
@@ -152,7 +170,8 @@ export function spawnOpts(token: string) {
 
 export async function cli(
     args: string,
-    token: string
+    token: string,
+    opts?: SpawnOpts
 ): Promise<{
     stdout: string;
     stderr: string;
@@ -162,7 +181,7 @@ export async function cli(
     const task = taskBin();
     const cmd = `${task} ${args}`;
     return new Promise((resolve) => {
-        exec(cmd, spawnOpts(token), (error, stdout, stderr) => {
+        exec(cmd, spawnOpts(token, opts), (error, stdout, stderr) => {
             const code = error && error.code ? error.code : 0;
             if (code !== 0) {
                 console.log('Command has failed with error:', error);
@@ -205,4 +224,16 @@ export async function listFilters(token: string): Promise<Filter[]> {
     }
 
     return res;
+}
+
+export async function createContext(
+    token: string,
+    name: string
+): Promise<string> {
+    const res = await withOptions.contexts.create(options(token), { name });
+    if (isAPIError(res)) {
+        throw new Error(`Getting Context: ${res.code}: ${res.message}`);
+    }
+
+    return res.id;
 }


### PR DESCRIPTION
This adds application state and application configuration to the
Taskforge CLI. As of now the configuration is underutilized (read: not
used at all).

Application state represents things that are not part of a user's
configuration as they are likely to change often and be changed by the
application itself.

Using Application state we now are able to leverage context switching so
that when a user runs task next they get a task that's most relevant to
their current situation. This feature was just added to the backend and
the SDK.
